### PR TITLE
strip dead deps, add release profile, fix chunking

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
-    "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-shell": "^2.3.5",
-    "framer-motion": "^12.34.0",
     "lucide-react": "^0.564.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,17 +18,22 @@ tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt", "sync"] }
 lancedb = "0.26"
 arrow-array = "57"
 arrow-schema = "57"
 fastembed = "5"
-notify = "7"
 pdf-extract = "0.10"
 walkdir = "2"
-futures = { version = "0.3", features = ["executor"] }
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
 anyhow = "1"
+mimalloc = { version = "0.1", default-features = false }
 tauri-plugin-global-shortcut = "2.3.1"
-image = "0.24"
 windows = { version = "0.58", features = ["Media_Ocr", "Graphics_Imaging", "Storage_Streams", "Foundation", "Storage", "Globalization"] }
 window-vibrancy = "0.7.1"
+
+[profile.release]
+opt-level = "s"
+lto = true
+codegen-units = 1
+strip = true

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 fn main() {
     recall_lite_lib::run()
 }


### PR DESCRIPTION
## Summary

- remove unused crates: `notify`, `image` (zero references in any .rs file)
- tokio `full` -> `rt` + `sync` (tauri owns the runtime, you only use `tokio::sync::Mutex`)
- futures `executor` feature -> `alloc` only (`TryStreamExt` is the only import, executor pulls in a second async runtime that's never called)
- remove unused npm deps: `framer-motion` (zero imports in App.tsx), `@tauri-apps/plugin-opener` (duplicate of plugin-shell's `open()`)
- add `[profile.release]`: opt-level=s, lto, codegen-units=1, strip=true (there was none, so cargo was using defaults — no LTO, no stripping, codegen-units=256)
- add `mimalloc` global allocator (windows HeapAlloc fragments over time, mimalloc handles allocation pressure better)
- fix text chunking: `.chars().chunks(2000)` splits mid-word which tanks embedding quality. new `chunk_on_boundaries()` walks back to nearest newline or space
- remove dead derives (`Serialize`/`Deserialize` on `Record` struct that's never serialized) and unused `Array` import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed unused dependencies to reduce package size and streamline the application.

* **Performance**
  * Improved text indexing with a boundary-aware chunking algorithm for more coherent results.
  * Switched to a more efficient memory allocator to improve runtime performance.
  * Tuned release build settings for smaller binaries and faster execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->